### PR TITLE
Use a polygon collider for player paddles

### DIFF
--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -172,7 +172,7 @@ void Ball::handleCollisions(Manager* _manager)
             polyPoints[i] = { player->position.x + x, player->position.y + y };
         }
 
-        // Check collisions using CheckCollisionPointPoly
+        // Check collisions using CheckCollisionCirclePoly
         if (CheckCollisionCirclePolygon(position, 5.0f, polyPoints, 8)) {
             // Calculate the collision point relative to the center of the circle
             float relativeX = position.x - player->position.x;

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -105,33 +105,38 @@ void Ball::update(Manager* _manager, int _screenWidth, int _screenHeight, float 
     // TODO: ADD GLOBAL HITBOX VAR
     // if (IsKeyDown(KEY_H)) showHitboxes = !showHitboxes;
 }
-Vector2 polyPoints[3];
+Vector2 polyPoints[8];
 void Ball::handleCollisions(Manager* _manager)
 {
+    const int numPoints = 8; // Number of points in the collider
+
+    // Offsets for the collider points
+    Vector2 offsets[numPoints] = {
+        { 15.0f, -5.0f },
+        { 2.0f, -3.0f },
+        { -10.0f, -3.0f },
+        { -23.0f, -5.0f },
+        { -23.0f, -8.0f },
+        { -10.0f, -6.0f },
+        { 2.0f, -6.0f },
+        { 15.0f, -8.0f }
+    };
     // Iterate through players and check collisions
     for (Player* player : _manager->players) {
-        // Define the offsets for the collider points
-        Vector2 offset1 = { -3.0f, -1.0f };
-        Vector2 offset2 = { -22.0f, -8.0f };
-        Vector2 offset3 = { 14.0f, -8.0f };
         float rotationAngle = player->rotation * (float)M_PI / 180.0f;
+        for (int i = 0; i < numPoints; ++i) {
+            float x = offsets[i].x * cosf(rotationAngle) - offsets[i].y * sinf(rotationAngle);
+            float y = offsets[i].x * sinf(rotationAngle) + offsets[i].y * cosf(rotationAngle);
 
-        // Rotate each point and apply the offsets
-        polyPoints[0] = {
-            player->position.x + (offset1.x * cosf(rotationAngle) - offset1.y * sinf(rotationAngle)),
-            player->position.y + (offset1.x * sinf(rotationAngle) + offset1.y * cosf(rotationAngle))
-        };
+            polyPoints[i] = {
+                player->position.x + x,
+                player->position.y + y
+            };
+            std::cout << polyPoints[i].x << std::endl;
+        }
+        // TODO: Use the correct number of points and angles based on your
+        // game's requirements
 
-        polyPoints[1] = {
-            player->position.x + (offset2.x * cosf(rotationAngle) - offset2.y * sinf(rotationAngle)),
-            player->position.y + (offset2.x * sinf(rotationAngle) + offset2.y * cosf(rotationAngle))
-        };
-
-        polyPoints[2] = {
-            player->position.x + (offset3.x * cosf(rotationAngle) - offset3.y * sinf(rotationAngle)),
-            player->position.y + (offset3.x * sinf(rotationAngle) + offset3.y * cosf(rotationAngle))
-        };
-        // TODO: Use the correct number of points and angles based on your game's requirements
         // Check collisions using CheckCollisionPointPoly
         if (CheckCollisionPointPoly(position, polyPoints, 3)) {
             // Calculate the collision point relative to the center of the circle
@@ -153,9 +158,8 @@ void Ball::handleCollisions(Manager* _manager)
 void Ball::draw()
 {
     DrawCircle(position.x, position.y, outputDims.x, WHITE);
-    DrawPixel(polyPoints[0].x, polyPoints[0].y, RED);
-    DrawPixel(polyPoints[1].x, polyPoints[1].y, RED);
-    DrawPixel(polyPoints[2].x, polyPoints[2].y, RED);
-    DrawTriangle(polyPoints[1], polyPoints[0], polyPoints[2], BLUE);
+    for (int i = 0; i < 8; i++) {
+        DrawPixel(polyPoints[i].x, polyPoints[i].y, RED);
+    }
     // DrawRectangleLines(position.x - origin.x, position.y - origin.y, hitboxDims.x, hitboxDims.y, RED);
 }

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -106,43 +106,41 @@ void Ball::update(Manager* _manager, int _screenWidth, int _screenHeight, float 
     // if (IsKeyDown(KEY_H)) showHitboxes = !showHitboxes;
 }
 Vector2 polyPoints[8];
+Vector2 polyPoints2[8];
 void Ball::handleCollisions(Manager* _manager)
 {
     const int numPoints = 8; // Number of points in the collider
 
     // Offsets for the collider points
     Vector2 offsets[numPoints] = {
-        { 15.0f, -5.0f },
-        { 2.0f, -3.0f },
-        { -10.0f, -3.0f },
-        { -23.0f, -5.0f },
-        { -23.0f, -8.0f },
-        { -10.0f, -6.0f },
-        { 2.0f, -6.0f },
-        { 15.0f, -8.0f }
+        { 20.0f, -1.0f },
+        { 2.0f, 2.0f },
+        { -10.0f, 2.0f },
+        { -28.0f, -1.0f },
+        { -26.0f, -14.0f },
+        { -10.0f, -12.0f },
+        { 2.0f, -12.0f },
+        { 18.0f, -14.0f }
     };
     // Iterate through players and check collisions
     for (Player* player : _manager->players) {
         float rotationAngle = player->rotation * (float)M_PI / 180.0f;
         for (int i = 0; i < numPoints; ++i) {
-            float x = offsets[i].x * cosf(rotationAngle) - offsets[i].y * sinf(rotationAngle);
-            float y = offsets[i].x * sinf(rotationAngle) + offsets[i].y * cosf(rotationAngle);
+            float x = offsets[i].x * cosf(rotationAngle) -
+                      offsets[i].y * sinf(rotationAngle);
+            float y = offsets[i].x * sinf(rotationAngle) +
+                      offsets[i].y * cosf(rotationAngle);
 
-            polyPoints[i] = {
-                player->position.x + x,
-                player->position.y + y
-            };
-            std::cout << polyPoints[i].x << std::endl;
+            polyPoints[i] = { player->position.x + x, player->position.y + y };
         }
         // TODO: Use the correct number of points and angles based on your
         // game's requirements
 
         // Check collisions using CheckCollisionPointPoly
-        if (CheckCollisionPointPoly(position, polyPoints, 3)) {
+        if (CheckCollisionPointPoly(position, polyPoints, 8)) {
             // Calculate the collision point relative to the center of the circle
             float relativeX = position.x - player->position.x;
             float relativeY = position.y - player->position.y;
-            std::cout << relativeX << ", " << relativeY << std::endl;
 
             // Calculate the angle of collision
             float collisionAngle = atan2f(relativeY, relativeX);

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -193,9 +193,4 @@ void Ball::draw()
 {
     DrawCircle(position.x, position.y, outputDims.x, WHITE);
     // DrawRectangleLines(position.x - origin.x, position.y - origin.y, hitboxDims.x, hitboxDims.y, RED);
-
-    // Draw player collider
-    // for (int i = 0; i < 8; i++) {
-    //     DrawPixel(polyPoints[i].x, polyPoints[i].y, RED);
-    // }
 }

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -105,16 +105,39 @@ void Ball::update(Manager* _manager, int _screenWidth, int _screenHeight, float 
     // TODO: ADD GLOBAL HITBOX VAR
     // if (IsKeyDown(KEY_H)) showHitboxes = !showHitboxes;
 }
-
+Vector2 polyPoints[3];
 void Ball::handleCollisions(Manager* _manager)
 {
     // Iterate through players and check collisions
     for (Player* player : _manager->players) {
-        // TODO: Replace with poly collisions using CheckCollisionPointPoly()
-        if (CheckCollisionPointCircle({ position.x, position.y }, { player->position.x, player->position.y }, 25.0f)) {
+        // Define the offsets for the collider points
+        Vector2 offset1 = { -3.0f, -1.0f };
+        Vector2 offset2 = { -22.0f, -8.0f };
+        Vector2 offset3 = { 14.0f, -8.0f };
+        float rotationAngle = player->rotation * (float)M_PI / 180.0f;
+
+        // Rotate each point and apply the offsets
+        polyPoints[0] = {
+            player->position.x + (offset1.x * cosf(rotationAngle) - offset1.y * sinf(rotationAngle)),
+            player->position.y + (offset1.x * sinf(rotationAngle) + offset1.y * cosf(rotationAngle))
+        };
+
+        polyPoints[1] = {
+            player->position.x + (offset2.x * cosf(rotationAngle) - offset2.y * sinf(rotationAngle)),
+            player->position.y + (offset2.x * sinf(rotationAngle) + offset2.y * cosf(rotationAngle))
+        };
+
+        polyPoints[2] = {
+            player->position.x + (offset3.x * cosf(rotationAngle) - offset3.y * sinf(rotationAngle)),
+            player->position.y + (offset3.x * sinf(rotationAngle) + offset3.y * cosf(rotationAngle))
+        };
+        // TODO: Use the correct number of points and angles based on your game's requirements
+        // Check collisions using CheckCollisionPointPoly
+        if (CheckCollisionPointPoly(position, polyPoints, 3)) {
             // Calculate the collision point relative to the center of the circle
             float relativeX = position.x - player->position.x;
             float relativeY = position.y - player->position.y;
+            std::cout << relativeX << ", " << relativeY << std::endl;
 
             // Calculate the angle of collision
             float collisionAngle = atan2f(relativeY, relativeX);
@@ -130,5 +153,9 @@ void Ball::handleCollisions(Manager* _manager)
 void Ball::draw()
 {
     DrawCircle(position.x, position.y, outputDims.x, WHITE);
+    DrawPixel(polyPoints[0].x, polyPoints[0].y, RED);
+    DrawPixel(polyPoints[1].x, polyPoints[1].y, RED);
+    DrawPixel(polyPoints[2].x, polyPoints[2].y, RED);
+    DrawTriangle(polyPoints[1], polyPoints[0], polyPoints[2], BLUE);
     // DrawRectangleLines(position.x - origin.x, position.y - origin.y, hitboxDims.x, hitboxDims.y, RED);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ int main()
         (Vector2){ (float)screenWidth / 2, (float)(screenHeight / 2) },
         (Vector2){ 5.0, 5.0 },
         (Vector2){ 5.0, 5.0 },
-        0.1f);
+        0.25f);
 
     mgr->addEntity(p1);
     mgr->addEntity(p2);
@@ -108,8 +108,8 @@ int main()
         mgr->draw();
 
         // Draw collision circles - Remove when done implementing poly collisions
-        DrawCircle(p1->position.x, p1->position.y, p1->outputDims.x / 2, BLUE);
-        DrawCircle(p2->position.x, p2->position.y, p2->outputDims.x / 2, RED);
+        // DrawCircle(p1->position.x, p1->position.y, p1->outputDims.x / 2, BLUE);
+        // DrawCircle(p2->position.x, p2->position.y, p2->outputDims.x / 2, RED);
 
         DrawFPS(10, 10);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,10 +107,6 @@ int main()
         BeginDrawing();
         mgr->draw();
 
-        // Draw collision circles - Remove when done implementing poly collisions
-        // DrawCircle(p1->position.x, p1->position.y, p1->outputDims.x / 2, BLUE);
-        // DrawCircle(p2->position.x, p2->position.y, p2->outputDims.x / 2, RED);
-
         DrawFPS(10, 10);
 
         ClearBackground(BLACK);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ int main()
         (Vector2){ (float)screenWidth / 2, (float)(screenHeight / 2) },
         (Vector2){ 5.0, 5.0 },
         (Vector2){ 5.0, 5.0 },
-        0.25f);
+        0.2f);
 
     mgr->addEntity(p1);
     mgr->addEntity(p2);


### PR DESCRIPTION
Switched from `CheckCollisionPointCircle` to custom function `CheckCollisionCirclePoly` for the player's paddles to make the collider match the shape of the paddle. This improves the accuracy of the paddle collider.